### PR TITLE
Add support for ArkTS

### DIFF
--- a/src/lib/format/main/index.ts
+++ b/src/lib/format/main/index.ts
@@ -14,12 +14,12 @@ import { formatVueSource } from './vue';
 /**
  * A type representing file extensions supported.
  */
-export type Extension = 'js' | 'ts' | 'jsx' | 'tsx' | 'vue';
+export type Extension = 'js' | 'ts' | 'jsx' | 'tsx' | 'vue' | 'ets';
 
 /**
  * File extensions supported.
  */
-export const SUPPORTED_EXTENSIONS: Extension[] = ['js', 'ts', 'jsx', 'tsx', 'vue'];
+export const SUPPORTED_EXTENSIONS: Extension[] = ['js', 'ts', 'jsx', 'tsx', 'vue', 'ets'];
 
 /**
  * Format given source text from a file, asynchronously.


### PR DESCRIPTION
The ets extension is used by Huawei OpenHarmony development language [ArkTS](https://developer.huawei.com/consumer/en/doc/harmonyos-guides-V5/introduction-to-arkts-V5).

ArkTS basically is  a superset of TypeScript, so only need to  compatible the extension.